### PR TITLE
Fix iPadOS 27 beta3 v2 detection

### DIFF
--- a/GestaltEdit/ContentView.swift
+++ b/GestaltEdit/ContentView.swift
@@ -41,12 +41,12 @@ struct ContentView: View {
 private struct UnsupportedOSView: View {
     var body: some View {
         VStack(spacing: 16) {
-            Image(systemName: "iphone.slash")
+            Image(systemName: "exclamationmark.triangle")
                 .font(.system(size: 44))
                 .foregroundStyle(.secondary)
-            Text("Unsupported iOS Version")
+            Text("Unsupported OS Version")
                 .font(.title2.weight(.semibold))
-            Text("GestaltEdit currently supports only iOS 27 beta 1 through beta 4.")
+            Text("GestaltEdit currently supports only iOS and iPadOS 27 beta 1 through beta 4.")
                 .multilineTextAlignment(.center)
                 .foregroundStyle(.secondary)
         }

--- a/GestaltEdit/GestaltAccess.h
+++ b/GestaltEdit/GestaltAccess.h
@@ -15,8 +15,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (instancetype)shared;
 
-/// Returns whether this process is running on an iOS 27 build that GestaltEdit
-/// currently supports (developer beta 1 through beta 4).
+/// Returns whether this process is running on an iOS or iPadOS 27 build that
+/// GestaltEdit currently supports (developer beta 1 through beta 4).
 + (BOOL)isRunningSupportedOS;
 
 /// The Darwin build identifier used by the supported-OS check, such as

--- a/GestaltEdit/GestaltAccess.m
+++ b/GestaltEdit/GestaltAccess.m
@@ -93,10 +93,11 @@ static BOOL GestaltWriteAll(int fd, NSData *data)
     NSString *build = self.currentOSBuild;
 
     return version.majorVersion == 27 && (
-        [build isEqualToString:@"24A5355q"] || // iOS 27 beta 1
-        [build isEqualToString:@"24A5370h"] || // iOS 27 beta 2
-        [build isEqualToString:@"24A5380h"] || // iOS 27 beta 3
-        [build isEqualToString:@"24A5390f"]    // iOS 27 beta 4
+        [build isEqualToString:@"24A5355q"] || // iOS / iPadOS 27 beta 1
+        [build isEqualToString:@"24A5370h"] || // iOS / iPadOS 27 beta 2
+        [build isEqualToString:@"24A5380h"] || // iOS / iPadOS 27 beta 3
+        [build isEqualToString:@"24A5380i"] || // iPadOS 27 beta 3 v2
+        [build isEqualToString:@"24A5390f"]    // iOS / iPadOS 27 beta 4
     );
 }
 
@@ -106,7 +107,7 @@ static BOOL GestaltWriteAll(int fd, NSData *data)
 {
     if (!GestaltAccess.isRunningSupportedOS) {
         if (error) *error = GestaltError(0, NSLocalizedString(
-            @"GestaltEdit currently supports only iOS 27 beta 1 through beta 4.", nil));
+            @"GestaltEdit currently supports only iOS and iPadOS 27 beta 1 through beta 4.", nil));
         return NO;
     }
 

--- a/GestaltEdit/zh-Hans.lproj/Localizable.strings
+++ b/GestaltEdit/zh-Hans.lproj/Localizable.strings
@@ -16,8 +16,8 @@
 "This device does not officially support Siri AI. Force enabling spoofs the product, hardware, and CPU model. It may temporarily break Face ID, cause system instability or boot loops, and could require restoring the device. A backup will be created before writing." = "此设备并未正式支持 Siri AI。强制开启会伪装产品型号、硬件型号与 CPU 型号，可能暂时导致 Face ID 失效、系统不稳定或无限重启，并可能需要恢复设备。写入前会自动创建备份。";
 "Reading MobileGestalt…" = "正在读取 MobileGestalt…";
 "Unable to read MobileGestalt" = "无法读取 MobileGestalt";
-"Unsupported iOS Version" = "不支持的 iOS 版本";
-"GestaltEdit currently supports only iOS 27 beta 1 through beta 4." = "GestaltEdit 目前仅支持 iOS 27 beta 1 至 beta 4。";
+"Unsupported OS Version" = "不支持的系统版本";
+"GestaltEdit currently supports only iOS and iPadOS 27 beta 1 through beta 4." = "GestaltEdit 目前仅支持 iOS 和 iPadOS 27 beta 1 至 beta 4。";
 "Reload" = "重新读取";
 "Connected" = "已连接";
 "Current Device" = "当前设备";

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GestaltEdit
 
-GestaltEdit is a native SwiftUI MobileGestalt utility that runs directly on iPhone. It reads the device's `com.apple.MobileGestalt.plist` and provides common capability presets, a complete field editor, and backup/import/restore workflows.
+GestaltEdit is a native SwiftUI MobileGestalt utility that runs directly on iPhone and iPad. It reads the device's `com.apple.MobileGestalt.plist` and provides common capability presets, a complete field editor, and backup/import/restore workflows.
 
 > [!WARNING]
 > This project uses private APIs and modifies system cache data. Incorrect MobileGestalt values can break system features or UI behavior and may require restoring the device. Use it only on devices you own or are authorized to manage.
@@ -39,12 +39,12 @@ Importing only copies a file into GestaltEdit's backup library; it does not imme
 
 ## Requirements and signing
 
-- Supported system versions: iOS 27 beta 1 through beta 4 only
+- Supported system versions: iOS and iPadOS 27 beta 1 through beta 4 only
 - Xcode and a signing method that can install apps on the target device
 - Developer Mode enabled on the device
 - Bundle identifier: `me.ssus.gestaltedit`
 
-GestaltEdit checks the running system build before accessing MobileGestalt. The current release accepts only iOS 27 beta 1–4 (24A5355q, 24A5370h, 24A5380h, and 24A5390f). Apple may change these private behaviors at any time.
+GestaltEdit checks the running system build before accessing MobileGestalt. The current release accepts iOS and iPadOS 27 beta 1–4 (24A5355q, 24A5370h, 24A5380h, and 24A5390f), plus the revised iPadOS beta 3 build 24A5380i. Apple may change these private behaviors at any time.
 
 ## Building
 


### PR DESCRIPTION
Add iPadOS 27 beta3 v2 to GestaltAccess.m, Close issue https://github.com/frs0n/GestaltEdit/issues/24

Source: https://appleinsider.com/articles/26/07/13/ipados-27-macos-27-beta-3-get-a-version-2-update-as-public-betas-drop / https://github.com/blacktop/ipsw-diffs/blob/main/27_0_24A5390f_vs_27_0_24A5408d/DYLIBS/System/Library/PrivateFrameworks/SensingAlgsPadHostServiceJ8xx.framework/SensingAlgsPadHostServiceJ8xx.md