### PR TITLE
Add iOS 18 to supported system versions

### DIFF
--- a/GestaltEdit/ContentView.swift
+++ b/GestaltEdit/ContentView.swift
@@ -46,7 +46,7 @@ private struct UnsupportedOSView: View {
                 .foregroundStyle(.secondary)
             Text("Unsupported OS Version")
                 .font(.title2.weight(.semibold))
-            Text("GestaltEdit currently supports only iOS and iPadOS 27 beta 1 through beta 4.")
+            Text("GestaltEdit currently supports iOS and iPadOS 18 and 27 beta 1 through beta 4.")
                 .multilineTextAlignment(.center)
                 .foregroundStyle(.secondary)
         }

--- a/GestaltEdit/GestaltAccess.h
+++ b/GestaltEdit/GestaltAccess.h
@@ -15,8 +15,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (instancetype)shared;
 
-/// Returns whether this process is running on an iOS or iPadOS 27 build that
-/// GestaltEdit currently supports (developer beta 1 through beta 4).
+/// Returns whether this process is running on an iOS or iPadOS build that
+/// GestaltEdit currently supports: iOS / iPadOS 18, or 27 developer beta 1
+/// through beta 4.
 + (BOOL)isRunningSupportedOS;
 
 /// The Darwin build identifier used by the supported-OS check, such as

--- a/GestaltEdit/GestaltAccess.m
+++ b/GestaltEdit/GestaltAccess.m
@@ -92,14 +92,28 @@ static BOOL GestaltWriteAll(int fd, NSData *data)
     NSOperatingSystemVersion version = NSProcessInfo.processInfo.operatingSystemVersion;
     NSString *build = self.currentOSBuild;
 
-    return version.majorVersion == 27 && (
-        [build isEqualToString:@"24A5355q"] || // iOS / iPadOS 27 beta 1
-        [build isEqualToString:@"24A5370h"] || // iOS / iPadOS 27 beta 2
-        [build isEqualToString:@"24A5380h"] || // iOS / iPadOS 27 beta 3
-        [build isEqualToString:@"24A5380i"] || // iPadOS 27 beta 3 v2
-        [build isEqualToString:@"24A5380l"] || // iOS / iPadOS 27 Public Beta 1 (revised beta 3, see issue #51)
-        [build isEqualToString:@"24A5390f"]    // iOS / iPadOS 27 beta 4
-    );
+    // iOS / iPadOS 27 developer betas 1-4 (validated against the bad_query
+    // upstream, which targets iOS 26.0 - 26.6.1 / 27.0b4).
+    if (version.majorVersion == 27) {
+        return (
+            [build isEqualToString:@"24A5355q"] || // iOS / iPadOS 27 beta 1
+            [build isEqualToString:@"24A5370h"] || // iOS / iPadOS 27 beta 2
+            [build isEqualToString:@"24A5380h"] || // iOS / iPadOS 27 beta 3
+            [build isEqualToString:@"24A5380i"] || // iPadOS 27 beta 3 v2
+            [build isEqualToString:@"24A5380l"] || // iOS / iPadOS 27 Public Beta 1 (revised beta 3, see issue #51)
+            [build isEqualToString:@"24A5390f"]    // iOS / iPadOS 27 beta 4
+        );
+    }
+
+    // iOS / iPadOS 18: bad_query may work but is unverified upstream
+    // ("might also work on iOS 18 ... ymmv"). Accepted broadly so it can be
+    // exercised on real devices; the actual capability is gated at connect
+    // time by BadQueryBridgeAvailable().
+    if (version.majorVersion == 18) {
+        return build.length > 0;
+    }
+
+    return NO;
 }
 
 #pragma mark - Connection
@@ -108,7 +122,7 @@ static BOOL GestaltWriteAll(int fd, NSData *data)
 {
     if (!GestaltAccess.isRunningSupportedOS) {
         if (error) *error = GestaltError(0, NSLocalizedString(
-            @"GestaltEdit currently supports only iOS and iPadOS 27 beta 1 through beta 4.", nil));
+            @"GestaltEdit currently supports iOS and iPadOS 18 and 27 beta 1 through beta 4.", nil));
         return NO;
     }
 

--- a/GestaltEdit/zh-Hans.lproj/Localizable.strings
+++ b/GestaltEdit/zh-Hans.lproj/Localizable.strings
@@ -11,7 +11,7 @@
 "Reading MobileGestalt…" = "正在读取 MobileGestalt…";
 "Unable to read MobileGestalt" = "无法读取 MobileGestalt";
 "Unsupported OS Version" = "不支持的系统版本";
-"GestaltEdit currently supports only iOS and iPadOS 27 beta 1 through beta 4." = "GestaltEdit 目前仅支持 iOS 和 iPadOS 27 beta 1 至 beta 4。";
+"GestaltEdit currently supports iOS and iPadOS 18 and 27 beta 1 through beta 4." = "GestaltEdit 目前支持 iOS 和 iPadOS 18 以及 27 beta 1 至 beta 4。";
 "Reload" = "重新读取";
 "Connected" = "已连接";
 "Current Device" = "当前设备";

--- a/README.md
+++ b/README.md
@@ -67,12 +67,12 @@ Importing only copies a file into GestaltEdit's backup library; it does not imme
 
 ## Requirements and signing
 
-- Supported system versions: iOS and iPadOS 27 beta 1 through beta 4 only
+- Supported system versions: iOS and iPadOS 18, and 27 beta 1 through beta 4
 - A way to sign and install the IPA, such as [iLoader](https://github.com/nab138/iloader)
 - Developer Mode enabled on the device
 - Bundle identifier: `me.ssus.gestaltedit`
 
-GestaltEdit checks the running system build before accessing MobileGestalt. The current release accepts iOS and iPadOS 27 beta 1–4 (24A5355q, 24A5370h, 24A5380h, and 24A5390f), plus the revised iPadOS beta 3 build 24A5380i. Apple may change these private behaviors at any time.
+GestaltEdit checks the running system build before accessing MobileGestalt. The current release accepts iOS and iPadOS 18 (any build; bad_query support is unverified upstream, "ymmv") and 27 beta 1–4 (24A5355q, 24A5370h, 24A5380h, 24A5380i, 24A5380l, 24A5390f). Apple may change these private behaviors at any time.
 
 ## Installing with iLoader
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -67,12 +67,12 @@ GestaltEdit 是一款直接在 iPhone 和 iPad 上运行的 MobileGestalt 工具
 
 ## 系统要求与签名
 
-- 支持的系统版本：仅 iOS 与 iPadOS 27 beta 1 至 beta 4
+- 支持的系统版本：iOS 与 iPadOS 18，以及 27 beta 1 至 beta 4
 - 一种可以对 IPA 进行签名并安装的方式，例如 [iLoader](https://github.com/nab138/iloader)
 - 设备已开启开发者模式
 - Bundle identifier：`me.ssus.gestaltedit`
 
-GestaltEdit 在访问 MobileGestalt 前会检查当前系统版本号。当前版本接受 iOS 与 iPadOS 27 beta 1–4（24A5355q、24A5370h、24A5380h、24A5390f），以及 iPadOS beta 3 的修订版本 24A5380i。Apple 随时可能改变这些私有行为。
+GestaltEdit 在访问 MobileGestalt 前会检查当前系统版本号。当前版本接受 iOS 与 iPadOS 18（任意 build；bad_query 在 iOS 18 上的支持上游未验证，属 "ymmv"），以及 27 beta 1–4（24A5355q、24A5370h、24A5380h、24A5380i、24A5380l、24A5390f）。Apple 随时可能改变这些私有行为。
 
 ## 使用 iLoader 签名安装
 


### PR DESCRIPTION
## Summary

Extends `GestaltAccess.isRunningSupportedOS` to accept **iOS / iPadOS 18** in addition to the existing iOS / iPadOS 27 beta 1–4 range.

## What changed

- `GestaltAccess.m` — `isRunningSupportedOS` now returns `YES` for any iOS 18 build (`majorVersion == 18 && build.length > 0`). iOS 27 keeps its existing validated beta build whitelist. The real capability is still enforced at connect time by `BadQueryBridgeAvailable()`, so a build where `bad_query` is unavailable fails with a clear error rather than silently.
- `GestaltAccess.h` — updated the method doc comment.
- `ContentView.swift` + `zh-Hans.lproj/Localizable.strings` — updated the "unsupported OS" message to list 18.
- `README.md` / `README.zh-CN.md` — updated the supported-versions line.

## Important caveat (please test before merging)

The app's read/write path is built entirely on `bad_query` (`forcequitOS/bad_query`). Upstream states it targets **iOS 26.0 – 26.6.1 / 27.0b4** and notes it *"might also work on iOS 18 but I haven't tested literally at all so ymmv."* There is **no claim of iOS 17 support**, and iOS 17 is intentionally **not** enabled here.

So this PR lets the app *attempt* to run on iOS 18 — it does not guarantee `bad_query` will actually succeed on every 18 build. On a build where the ContainerManager APIs are unavailable, `BadQueryBridgeAvailable()` returns `NO` and the app reports the existing `bad_query` error. **I have not been able to verify on a physical iOS 18 device**, so confirmation on real hardware would be valuable before this is considered fully supported.

## Scope

iOS 17 is deliberately excluded (no upstream support claim). If you'd prefer a narrower 18 gating (e.g. a specific build allowlist) or want this split into a separate flag, happy to adjust.
